### PR TITLE
Improvement: Fix login page layout.

### DIFF
--- a/ckanext/adfs/templates/user/login.html
+++ b/ckanext/adfs/templates/user/login.html
@@ -2,8 +2,12 @@
 
 {% block subtitle %}{{ _('Login') }}{% endblock %}
 
-{% block pre_primary %}
-  <section class="module">
+{% block breadcrumb_content %}
+  <li class="active">{{ h.nav_link(_('Login'), controller='user', action='login') }}</li>
+{% endblock %}
+
+{% block primary_content %}
+ <section class="module">
     <div class="module-content">
         <h1 class="page-heading">NHS England Sign In</h1>
         <p>For employees of NHS England, click the NHS Login button below to
@@ -13,36 +17,51 @@
     </div>
   </section>
   <section class="module">
-    <div class="module-content">
+    <div class="module-content external-login">
       <h2 class="page-heading">External Login</h2>
       {% block form %}
         {% snippet "user/snippets/login_form.html", action=c.login_handler, error_summary=error_summary %}
-      {% endblock %}
-    </div>
+      {% endblock %} 
+    </div> 
   </section>
+{% endblock %}
+
+{% block secondary_content %}
   {% if h.check_access('user_create') %}
+  {% block help_register %}
     <section class="module module-narrow module-shallow">
       <h2 class="module-heading">{{ _('Need an Account?') }}</h2>
+      {% block help_register_inner %}
       <div class="module-content">
         <p>{% trans %}If you don't work for NHS England, then sign right up,
         it only takes a minute. (If you <em>do</em> work for NHS England use
         the NHS Sign In button.){% endtrans %}</p>
         <p class="action">
+        {% block help_register_button %}
           <a class="btn" href="{{ h.url_for(controller='user', action='register') }}">{{ _('Create an Account') }}</a>
+        {% endblock %}
         </p>
       </div>
+    {% endblock %}
     </section>
+  {% endblock %}
   {% endif %}
 
+  {% block help_forgotten %}
   <section class="module module-narrow module-shallow">
+  {% block help_forgotten_inner %}
     <h2 class="module-heading">{{ _('Forgotten your password?') }}</h2>
     <div class="module-content">
       <p>{% trans %}If you don't work for NHS England, use our password
       recovery form to reset it.{% endtrans %}</p>
       <p class="action">
+        {% block help_forgotten_button %}
         <a class="btn" href="{{ h.url_for(controller='user', action='request_reset') }}">{{ _('Forgot your password?') }}</a>
+        {% endblock %}
       </p>
     </div>
+    {% endblock %}
   </section>
+  {% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
Login page format was out of date. I cherry picked
the City of [Sydney update](https://github.com/reneenoble/ckanext-adfs/commit/a42f684b4e4816dcad129aef84d18c5c1ead3206)
to add in the proper block templating to
create the aside and main panels and to properly
extend the page template.

Without this the plugin shifts the page content
to the left of the default CKAN theme.

All references to 'City of Sydney' were removed
and the original NHS references were left for the
time being.